### PR TITLE
Use the shell provider to avoid "Command not found" errors 

### DIFF
--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -125,6 +125,7 @@ define archive::download (
           false => "curl ${insecure_arg} -o ${src_target}/${name} ${url}",
           default => fail ( "Unknown checksum value: '${checksum}'" ),
         },
+        provider => shell,
         creates => "${src_target}/${name}",
         logoutput => true,
         timeout => $timeout,


### PR DESCRIPTION
Leading parens cause problems on some systems. 

I ran into this error using puppet 2.7.9 on amazon linux (rhel 6)
