### PR TITLE
Use the shell provider to avoid "Command not found" errors

### DIFF
--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -125,6 +125,7 @@ define archive::download (
           false => "curl ${insecure_arg} -o ${src_target}/${name} ${url}",
           default => fail ( "Unknown checksum value: '${checksum}'" ),
         },
+        provider => shell,
         creates => "${src_target}/${name}",
         logoutput => true,
         timeout => $timeout,


### PR DESCRIPTION
Use the shell provider to avoid "Command not found" errors on systems where leading parens cause problems.
