### PR TITLE
archive::zip: add brackets to temp zip file name

### DIFF
--- a/manifests/zip.pp
+++ b/manifests/zip.pp
@@ -1,6 +1,6 @@
 define archive::zip($source, $target) {
   exec {"$name unpack":
-    command => "TMPFILE=\$(mktemp); curl -o \$TMPFILE.zip ${source} && unzip \$TMPFILE.zip -d ${target} && rm \$TMPFILE && rm \$TMPFILE.zip && touch ${name}",
+    command => "TMPFILE=\$(mktemp); curl -o \${TMPFILE}.zip ${source} && unzip \${TMPFILE}.zip -d ${target} && rm \$TMPFILE && rm \${TMPFILE}.zip && touch ${name}",
     creates => $name,
     require => Package["unzip"],
   }


### PR DESCRIPTION
Add brackets around the tmp zip file variable.
