### PR TITLE
Curl should be silent, unless there is an error to report

### DIFF
--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -83,7 +83,7 @@ define archive::download (
             }
 
             exec {"download digest of archive $name":
-              command => "curl ${insecure_arg} ${redirect_arg} -o ${src_target}/${name}.${digest_type} ${digest_src}",
+              command => "curl -s -S ${insecure_arg} ${redirect_arg} -o ${src_target}/${name}.${digest_type} ${digest_src}",
               creates => "${src_target}/${name}.${digest_type}",
               timeout => $timeout,
               notify  => Exec["download archive $name and check sum"],
@@ -127,7 +127,7 @@ define archive::download (
   case $ensure {
     present: {
       exec {"download archive $name and check sum":
-        command   => "curl ${insecure_arg} ${redirect_arg} -o ${src_target}/${name} ${url}",
+        command   => "curl -s -S ${insecure_arg} ${redirect_arg} -o ${src_target}/${name} ${url}",
         creates   => "${src_target}/${name}",
         logoutput => true,
         timeout   => $timeout,

--- a/manifests/tar_gz.pp
+++ b/manifests/tar_gz.pp
@@ -1,6 +1,6 @@
 define archive::tar_gz($source, $target) {
   exec {"$name unpack":
-    command => "curl ${source} | tar -xzf - -C ${target} && touch ${name}",
+    command => "curl -s -S ${source} | tar -xzf - -C ${target} && touch ${name}",
     creates => $name,
     require => Package[curl],
   }

--- a/manifests/zip.pp
+++ b/manifests/zip.pp
@@ -1,6 +1,6 @@
 define archive::zip($source, $target) {
   exec {"$name unpack":
-    command => "TMPFILE=\$(mktemp); curl -o \${TMPFILE}.zip ${source} && unzip \${TMPFILE}.zip -d ${target} && rm \$TMPFILE && rm \${TMPFILE}.zip && touch ${name}",
+    command => "TMPFILE=\$(mktemp); curl -s -S -o \${TMPFILE}.zip ${source} && unzip \${TMPFILE}.zip -d ${target} && rm \$TMPFILE && rm \${TMPFILE}.zip && touch ${name}",
     creates => $name,
     require => Package['unzip'],
   }


### PR DESCRIPTION
It's pretty annoying to get curl(1) output in the middle of an agent run like such:

```
Notice: /Stage[main]/Tomcat::Juli::Debian/Archive::Download[tomcat-juli.jar]/Package[curl]/ensure: ensure changed 'purged' to 'present'
Notice: /Stage[main]/Tomcat::Juli::Debian/Archive::Download[tomcat-juli-adapters.jar]/Exec[download digest of archive tomcat-juli-adapters.jar]/returns: executed successfully
Notice: /Stage[main]/Tomcat::Juli::Debian/Archive::Download[tomcat-juli.jar]/Exec[download digest of archive tomcat-juli.jar]/returns: executed successfully
Notice: /Stage[main]/Tomcat::Juli::Debian/Archive::Download[tomcat-juli.jar]/Exec[download archive tomcat-juli.jar and check sum]/returns:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
Notice: /Stage[main]/Tomcat::Juli::Debian/Archive::Download[tomcat-juli.jar]/Exec[download archive tomcat-juli.jar and check sum]/returns:                                  Dload  Upload   Total   Spent    Left  Speed
100 63439  100 63439    0     0  10670      0  0:00:05  0:00:05 --:--:-- 81751xec[download archive tomcat-juli.jar and check sum]/returns: 
Notice: /Stage[main]/Tomcat::Juli::Debian/Archive::Download[tomcat-juli.jar]/Exec[download archive tomcat-juli.jar and check sum]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Tomcat::Juli::Debian/Archive::Download[tomcat-juli.jar]/Exec[rm-on-error-tomcat-juli.jar]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Tomcat::Juli::Debian/File[/bin/tomcat-juli.jar]/ensure: created
Notice: /Stage[main]/Tomcat::Juli::Debian/Archive::Download[tomcat-juli-adapters.jar]/Exec[download archive tomcat-juli-adapters.jar and check sum]/returns:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
Notice: /Stage[main]/Tomcat::Juli::Debian/Archive::Download[tomcat-juli-adapters.jar]/Exec[download archive tomcat-juli-adapters.jar and check sum]/returns:                                  Dload  Upload   Total   Spent    Left  Speed
100 22996  100 22996    0     0   4095      0  0:00:05  0:00:05 --:--:-- 50429rs.jar]/Exec[download archive tomcat-juli-adapters.jar and check sum]/returns: 
```

So perhaps curl should not print anything (`-s`) unless there's an error to report (`-S`)?
