### PR TITLE
Added default path to all execs

### DIFF
--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -84,6 +84,7 @@ define archive::download (
 
             exec {"download digest of archive $name":
               command => "curl -s -S ${insecure_arg} ${redirect_arg} -o ${src_target}/${name}.${digest_type} ${digest_src}",
+              path    => '/usr/bin',
               creates => "${src_target}/${name}.${digest_type}",
               timeout => $timeout,
               notify  => Exec["download archive $name and check sum"],
@@ -131,6 +132,7 @@ define archive::download (
     present: {
       exec {"download archive $name and check sum":
         command   => "curl -s -S ${insecure_arg} ${redirect_arg} -o ${src_target}/${name} ${url}",
+        path      => '/usr/bin',
         creates   => "${src_target}/${name}",
         logoutput => true,
         timeout   => $timeout,
@@ -147,6 +149,7 @@ define archive::download (
 
       exec {"rm-on-error-${name}":
         command     => "rm -f ${src_target}/${name} ${src_target}/${name}.${digest_type} && exit 1",
+        path        => '/usr/bin',
         unless      => $checksum_cmd,
         cwd         => $src_target,
         refreshonly => true,

--- a/manifests/extract.pp
+++ b/manifests/extract.pp
@@ -61,6 +61,7 @@ define archive::extract (
           'tgz2'    => "mkdir -p ${target} && ${extract_tarbz2}",
           default   => fail ( "Unknown extension value '${extension}'" ),
         },
+        path    => '/usr/bin',
         creates => $extract_dir,
         timeout => $timeout
       }

--- a/manifests/tar_gz.pp
+++ b/manifests/tar_gz.pp
@@ -1,6 +1,7 @@
 define archive::tar_gz($source, $target) {
   exec {"$name unpack":
     command => "curl -s -S ${source} | tar -xzf - -C ${target} && touch ${name}",
+    path    => '/usr/bin',
     creates => $name,
     require => Package[curl],
   }

--- a/manifests/zip.pp
+++ b/manifests/zip.pp
@@ -1,6 +1,7 @@
 define archive::zip($source, $target) {
   exec {"$name unpack":
     command => "TMPFILE=\$(mktemp); curl -s -S -o \${TMPFILE}.zip ${source} && unzip \${TMPFILE}.zip -d ${target} && rm \$TMPFILE && rm \${TMPFILE}.zip && touch ${name}",
+    path    => '/usr/bin',
     creates => $name,
     require => Package['unzip'],
   }


### PR DESCRIPTION
In newer versions of puppet, paths need to be fully qualified. This is workaround so the module works with them.
