### PR TITLE
allow disabling of no-checksum notices in puppetmaster logs

### DIFF
--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -14,6 +14,7 @@ Parameters:
 - *$src_target: Default value "/usr/src".
 - *$allow_insecure: Default value false.
 - *$follow_redirects: Default value false.
+- *$verbose: Default value true.
 
 Example usage:
 
@@ -40,6 +41,7 @@ define archive::download (
   $src_target='/usr/src',
   $allow_insecure=false,
   $follow_redirects=false,
+  $verbose=true,
 ) {
 
   $insecure_arg = $allow_insecure ? {
@@ -122,7 +124,9 @@ define archive::download (
     }
     false :  {
       $checksum_cmd = undef # Fix for strict_variables
-      notice 'No checksum for this archive'
+      if $verbose {
+        notice 'No checksum for this archive'
+      }
     }
     default: { fail ( "Unknown checksum value: '${checksum}'" ) }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,7 @@ Parameters:
 - *$timeout: Default value 120
 - *$allow_insecure: Default value false
 - *$follow_redirects: Default value false
+- *$verbose: Default value true
 
 Example usage:
 
@@ -42,6 +43,7 @@ define archive (
   $src_target='/usr/src',
   $allow_insecure=false,
   $follow_redirects=false,
+  $verbose=true,
 ) {
 
   archive::download {"${name}.${extension}":
@@ -55,6 +57,7 @@ define archive (
     src_target       => $src_target,
     allow_insecure   => $allow_insecure,
     follow_redirects => $follow_redirects,
+    verbose          => $verbose,
   }
 
   archive::extract {$name:


### PR DESCRIPTION
If checksum disabled for download, allow new verbose parameter to disable logging this fact on the puppetmaster.

Default is verbose=true, to retain old behaviour.
