### PR TITLE
dowload.pp: Quote the URL to get the data from

### DIFF
--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -82,7 +82,7 @@ define archive::download (
             }
 
             exec {"download digest of archive ${name}":
-              command => "curl -s -S ${insecure_arg} ${redirect_arg} -o ${src_target}/${name}.${digest_type} ${digest_src}",
+              command => "curl -s -S ${insecure_arg} ${redirect_arg} -o ${src_target}/${name}.${digest_type} '${digest_src}'",
               creates => "${src_target}/${name}.${digest_type}",
               timeout => $timeout,
               notify  => Exec["download archive ${name} and check sum"],
@@ -145,7 +145,7 @@ define archive::download (
         default => undef,
       }
       exec {"download archive ${name} and check sum":
-        command     => "curl -s -S ${insecure_arg} ${redirect_arg} -o ${src_target}/${name} ${url}",
+        command     => "curl -s -S ${insecure_arg} ${redirect_arg} -o ${src_target}/${name} '${url}'",
         creates     => "${src_target}/${name}",
         logoutput   => true,
         timeout     => $timeout,


### PR DESCRIPTION
When URLs contains not only alphabetical characters like '&' the
URL parsed is not the one expected.

For example the following URL needs to be quoted to work as expected
'http://downloads.sourceforge.net/project/pentaho/Business%20Intelligence%20Server/5.1/biserver-ce-5.1.0.0-752.zip?r=&ts=1410402175&use_mirror=iweb'
