### PR TITLE
Fail download on server errors

### DIFF
--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -9,7 +9,7 @@
 # - *$digest_string: Default value ""
 # - *$digest_type: Default value "md5".
 # - *$timeout: Default value 120.
-# - *$src_target: Default value "/usr/src".
+# - *$src_target: Default value "/usr/src".cu
 # - *$allow_insecure: Default value false.
 # - *$follow_redirects: Default value false.
 # - *$verbose: Default value true.
@@ -82,7 +82,7 @@ define archive::download (
             }
 
             exec {"download digest of archive ${name}":
-              command => "curl -s -S ${insecure_arg} ${redirect_arg} -o ${src_target}/${name}.${digest_type} '${digest_src}'",
+              command => "curl -s -S -f ${insecure_arg} ${redirect_arg} -o ${src_target}/${name}.${digest_type} '${digest_src}'",
               creates => "${src_target}/${name}.${digest_type}",
               timeout => $timeout,
               notify  => Exec["download archive ${name} and check sum"],


### PR DESCRIPTION
From the curl man page -

```
       -f/--fail
              (HTTP)  Fail  silently  (no output at all) on server errors. This is mostly done to better enable scripts etc to better deal with failed attempts. In normal cases when a
              HTTP server fails to deliver a document, it returns an HTML document stating so (which often also describes why and more). This flag will prevent  curl  from  outputting
              that and return error 22.

              This  method  is  not fail-safe and there are occasions where non-successful response codes will slip through, especially when authentication is involved (response codes
              401 and 407).
```
