### PR TITLE
fix error when checksum is disabled

### DIFF
--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -128,7 +128,7 @@ define archive::download (
       }
     }
     false :  {
-      $checksum_cmd = undef # Fix for strict_variables
+      $checksum_cmd = 'echo check' # Fix for strict_variables
       if $verbose {
         notice 'No checksum for this archive'
       }

--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -162,6 +162,7 @@ define archive::download (
         unless      => $checksum_cmd,
         cwd         => $src_target,
         path        => $path,
+        require     => Exec["download archive ${name} and check sum"],
         refreshonly => true,
       }
     }


### PR DESCRIPTION
When checksum is disabled on the archive, an exception error is thrown because ``$checksum_cmd`` is ``undef`` and ``Exec["rm-on-error-${name}"]`` is being run all the time, even though it should run only on checksum error.
This pr fixed it.
Thanks