### PR TITLE
Use gtar on Solaris and allow general overriding of tar command.

### DIFF
--- a/manifests/extract.pp
+++ b/manifests/extract.pp
@@ -41,6 +41,10 @@ define archive::extract (
   $strip_components=0,
   $purge=false,
   $user=undef,
+  $tar_command=$::osfamily ? {
+    'Solaris' => 'gtar',
+    default   => 'tar',
+  },
 ) {
 
   if $root_dir {
@@ -53,9 +57,9 @@ define archive::extract (
     'present': {
 
       $extract_zip    = "unzip -o ${src_target}/${name}.${extension} -d ${target}"
-      $extract_targz  = "tar --no-same-owner --no-same-permissions --strip-components=${strip_components} -xzf ${src_target}/${name}.${extension} -C ${target}"
-      $extract_tarbz2 = "tar --no-same-owner --no-same-permissions --strip-components=${strip_components} -xjf ${src_target}/${name}.${extension} -C ${target}"
-      $extract_tarxz  = "tar --no-same-owner --no-same-permissions --strip-components=${strip_components} -xpf ${src_target}/${name}.${extension} -C ${target}"
+      $extract_targz  = "${tar_command} --no-same-owner --no-same-permissions --strip-components=${strip_components} -xzf ${src_target}/${name}.${extension} -C ${target}"
+      $extract_tarbz2 = "${tar_command} --no-same-owner --no-same-permissions --strip-components=${strip_components} -xjf ${src_target}/${name}.${extension} -C ${target}"
+      $extract_tarxz  = "${tar_command} --no-same-owner --no-same-permissions --strip-components=${strip_components} -xpf ${src_target}/${name}.${extension} -C ${target}"
 
       $purge_command = $purge ? {
         true    => "rm -rf ${target} && ",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,6 +49,7 @@ define archive (
   $proxy_server=undef,
   $purge_target=false,
   $user=undef,
+  $tar_command=undef,
 ) {
 
   archive::download {"${name}.${extension}":
@@ -76,6 +77,7 @@ define archive (
     extension        => $extension,
     timeout          => $timeout,
     strip_components => $strip_components,
+    tar_command      => $tar_command,
     require          => Archive::Download["${name}.${extension}"],
     user             => $user,
   }

--- a/spec/defines/archive_spec.rb
+++ b/spec/defines/archive_spec.rb
@@ -67,6 +67,19 @@ describe 'archive' do
 
         it { is_expected.to compile.with_all_deps }
       end
+
+      context 'with custom tar command' do
+        let(:params) do
+          {
+            :url         => 'http://archive.apache.org/dist/tomcat/tomcat-6/v6.0.26/bin/apache-tomcat-6.0.26.tar.gz',
+            :target      => '/opt',
+            :tar_command => 'xtar',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { should contain_archive__extract('apache-tomcat-6.0.26').with_tar_command('xtar') }
+      end
     end
   end
 end

--- a/spec/defines/extract_spec.rb
+++ b/spec/defines/extract_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+ 
+describe 'archive::extract' do
+
+  default_facts = {
+    :path => '/usr/bin:/bin',
+    :osfamily => 'Debian'
+  }
+
+  let(:title) { 'apache-tomcat-6.0.26' }
+  let(:params) {{
+    :target => '/opt'
+  }}
+
+  context 'with minimal parameters' do
+    let(:facts) { default_facts }
+    it { should contain_exec('apache-tomcat-6.0.26 unpack').with_command(/&& tar /) }
+  end
+
+  context 'in Solaris' do
+    let (:facts) { default_facts.merge({
+      :osfamily => 'Solaris'
+    }) }
+    it { should contain_exec('apache-tomcat-6.0.26 unpack').with_command(/&& gtar /) }
+  end
+  
+end


### PR DESCRIPTION
On Solaris the `tar` command is a Sun utility with totally different options, so needless to say it doesn't work. Recent Solaris also has `gtar` which is the GNU tar we all know and love from Linux, so this change uses `gtar` on Solaris. It also lets you manually specify the tar command to use. Also a couple of rspec tests to verify the behaviour.