### PR TITLE
Add access to `--strip-components=n` tarball extract flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ checksum => false
 
 You can specify a ```digest_url```, ```digest_string``` and ```digest_type``` to verify archive integrity.
 
+For `.tar.gz` and `tar.bz2` archives, the extract step's `--strip-components=n` flag can be accessed. This can be used to [change the name of the extracted directory](http://unix.stackexchange.com/questions/11018/how-to-choose-directory-name-during-untarring).
+
+```
+strip_components => 1
+```
+
 This full example will download the [packer](packer.io) tool to ```/usr/local/bin```:
 
 ```

--- a/manifests/extract.pp
+++ b/manifests/extract.pp
@@ -36,6 +36,7 @@ define archive::extract (
   $extension='tar.gz',
   $timeout=120,
   $path=$::path,
+  $strip_components=0,
 ) {
 
   if $root_dir {
@@ -48,8 +49,8 @@ define archive::extract (
     'present': {
 
       $extract_zip    = "unzip -o ${src_target}/${name}.${extension} -d ${target}"
-      $extract_targz  = "tar --no-same-owner --no-same-permissions -xzf ${src_target}/${name}.${extension} -C ${target}"
-      $extract_tarbz2 = "tar --no-same-owner --no-same-permissions -xjf ${src_target}/${name}.${extension} -C ${target}"
+      $extract_targz  = "tar --no-same-owner --no-same-permissions --strip-components=${strip_components} -xzf ${src_target}/${name}.${extension} -C ${target}"
+      $extract_tarbz2 = "tar --no-same-owner --no-same-permissions --strip-components=${strip_components} -xjf ${src_target}/${name}.${extension} -C ${target}"
 
       $command = $extension ? {
         'zip'     => "mkdir -p ${target} && ${extract_zip}",

--- a/manifests/extract.pp
+++ b/manifests/extract.pp
@@ -9,6 +9,7 @@
 # - *$root_dir: Default value "".
 # - *$extension: Default value ".tar.gz".
 # - *$timeout: Default value 120.
+# - *$strip_components: Default value 0.
 #
 # Example usage:
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,7 @@ define archive (
   $allow_insecure=false,
   $follow_redirects=false,
   $verbose=true,
+  $strip_components=0,
 ) {
 
   archive::download {"${name}.${extension}":
@@ -58,12 +59,13 @@ define archive (
   }
 
   archive::extract {$name:
-    ensure     => $ensure,
-    target     => $target,
-    src_target => $src_target,
-    root_dir   => $root_dir,
-    extension  => $extension,
-    timeout    => $timeout,
-    require    => Archive::Download["${name}.${extension}"],
+    ensure           => $ensure,
+    target           => $target,
+    src_target       => $src_target,
+    root_dir         => $root_dir,
+    extension        => $extension,
+    timeout          => $timeout,
+    strip_components => $strip_components,
+    require          => Archive::Download["${name}.${extension}"],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,7 @@
 # - *$allow_insecure: Default value false
 # - *$follow_redirects: Default value false
 # - *$verbose: Default value true
+# - *$strip_components: Default value 0
 #
 # Example usage:
 #


### PR DESCRIPTION
My goal is to give `camptocamp-archive` access to the `--strip-components` flag in a backwards-compatible way.

The examples below demonstrate that `gini-archive` implemented `--strip-components` in a backwards-incompatible way, while the code proposed in my PR is API backwards compatible with the current `camptocamp-archive` code *and* adds access to the `--strip-components` flag.

### Examples

#### Strip 0 components

Relevant params overridden (everything else irrelevant or default):

```
target='/opt/'
name='opendaylight-0.2.2'
```

##### Current code

Note that this example, `--strip-components=0`, is equivalent to not including that flag at all. That's what makes it possible to compare to the current code, which doesn't actually support `--strip-components`.

Yields this extract command:

```
tar --no-same-owner --no-same-permissions -xzf /usr/src/opendaylight-0.2.2.tar.gz -C /opt/
```

And this overall command:

```
mkdir -p /opt/ && tar --no-same-owner --no-same-permissions -xzf /usr/src/opendaylight-0.2.2.tar.gz -C /opt/
```

When executed:

```
[/usr/src]$ ls opendaylight-0.2.2.tar.gz
opendaylight-0.2.2.tar.gz
[/usr/src]$ ls /opt
apacheds-2.0.0_M19  google  vagrant
[/usr/src]$ mkdir -p /opt/ && tar --no-same-owner --no-same-permissions -xzf /usr/src/opendaylight-0.2.2.tar.gz -C /opt/
[/usr/src]$ ls /opt
apacheds-2.0.0_M19  distribution-karaf-0.2.2-Helium-SR2  google  vagrant
[/usr/src]$ ls /opt/distribution-karaf-0.2.2-Helium-SR2
bin  configuration  data  deploy  etc  externalapps  lib  system  version.properties
```

##### gini-archive code

Yields this extract command:

```
tar --no-same-owner --no-same-permissions --strip-components=0 -xzf /usr/src/opendaylight-0.2.2.tar.gz -C /opt/opendaylight-0.2.2
```

And this overall command:

```
mkdir -p /opt/opendaylight-0.2.2 && tar --no-same-owner --no-same-permissions --strip-components=0 -xzf /usr/src/opendaylight-0.2.2.tar.gz -C /opt/opendaylight-0.2.2
```

When executed:

```
[/usr/src]$ ls opendaylight-0.2.2.tar.gz
opendaylight-0.2.2.tar.gz
[/usr/src]$ ls /opt
apacheds-2.0.0_M19  google  vagrant
[/usr/src]$ mkdir -p /opt/opendaylight-0.2.2 && tar --no-same-owner --no-same-permissions --strip-components=0 -xzf /usr/src/opendaylight-0.2.2.tar.gz -C /opt/opendaylight-0.2.2
[/usr/src]$ ls /opt
apacheds-2.0.0_M19  google  opendaylight-0.2.2  vagrant
[/usr/src]$ ls /opt/opendaylight-0.2.2
distribution-karaf-0.2.2-Helium-SR2
```

Note that this is different from its parent mod - the `distribution-karaf-0.2.2-Helium-SR2` directory is inside a `opendaylight-0.2.2` directory. The two APIs have diverged and it would take backwards-incompatible changes to reconcile them.

##### Proposed code

Yields this extract command:

```
tar --no-same-owner --no-same-permissions --strip-components=0 -xzf /usr/src/opendaylight-0.2.2.tar.gz -C /opt/
```

And this overall command:

```
mkdir -p /opt/ && tar --no-same-owner --no-same-permissions --strip-components=0 -xzf /usr/src/opendaylight-0.2.2.tar.gz -C /opt/
```

When executed:

```
[/usr/src]$ ls opendaylight-0.2.2.tar.gz
opendaylight-0.2.2.tar.gz
[/usr/src]$ ls /opt
apacheds-2.0.0_M19  google  vagrant
[/usr/src]$ mkdir -p /opt/ && tar --no-same-owner --no-same-permissions --strip-components=0 -xzf /usr/src/opendaylight-0.2.2.tar.gz -C /opt/
[/usr/src]$ ls /opt
apacheds-2.0.0_M19  distribution-karaf-0.2.2-Helium-SR2  google  vagrant
[/usr/src]$ ls /opt/distribution-karaf-0.2.2-Helium-SR2
bin  configuration  data  deploy  etc  externalapps  lib  system  version.properties
```

The PR's result is the same as the result of the current code. API backwards compatibility is maintained.

#### Strip 1 component

Relevant params overridden (everything else irrelevant or default):

```
target='/opt/opendaylight-0.2.2'
name='opendaylight-0.2.2'
strip_components=1
```

##### Current code

Can't demonstrate with current code, as it doesn't support `--strip-components`.

##### Proposed code

Yields this extract command:

```
tar --no-same-owner --no-same-permissions --strip-components=1 -xzf /usr/src/opendaylight-0.2.2.tar.gz -C /opt/opendaylight-0.2.2
```

And this overall command:

```
mkdir -p /opt/opendaylight-0.2.2 && tar --no-same-owner --no-same-permissions --strip-components=1 -xzf /usr/src/opendaylight-0.2.2.tar.gz -C /opt/opendaylight-0.2.2
```

When executed:

```
[/usr/src]$ ls opendaylight-0.2.2.tar.gz
opendaylight-0.2.2.tar.gz
[/usr/src]$ ls /opt
apacheds-2.0.0_M19  google  vagrant
[/usr/src]$ mkdir -p /opt/opendaylight-0.2.2 && tar --no-same-owner --no-same-permissions --strip-components=1 -xzf /usr/src/opendaylight-0.2.2.tar.gz -C /opt/opendaylight-0.2.2
[/usr/src]$ ls /opt
apacheds-2.0.0_M19  google  opendaylight-0.2.2  vagrant
[/usr/src]$ ls /opt/opendaylight-0.2.2
bin  configuration  data  deploy  etc  externalapps  lib  system  version.properties
```

This is the desired result - the default extract dir (`distribution-karaf-0.2.2-Helium-SR2` in this case) was striped off and replaced with one named `opendaylight-0.2.2` (the second level of the `target` param).