### PR TITLE
On some ubuntu systems curl -o doesnt work, changed to curl $src > $tgt

### DIFF
--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -102,7 +102,7 @@ define archive::download (
             }
 
             exec {"download digest of archive ${name}":
-              command => "curl -s -S ${insecure_arg} ${redirect_arg} -o ${src_target}/${name}.${digest_type} '${digest_src}'",
+              command => "curl -s -S ${insecure_arg} ${redirect_arg} '${digest_src}' > ${src_target}/${name}.${digest_type}",
               creates => "${src_target}/${name}.${digest_type}",
               timeout => $timeout,
               path    => $path,
@@ -144,7 +144,7 @@ define archive::download (
         default => undef,
       }
       exec {"download archive ${name} and check sum":
-        command     => "curl -s -S ${insecure_arg} ${redirect_arg} -o ${src_target}/${name} '${url}'",
+        command     => "curl -s -S ${insecure_arg} ${redirect_arg} '${url}' > ${src_target}/${name}",
         creates     => "${src_target}/${name}",
         logoutput   => true,
         timeout     => $timeout,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,10 @@ define archive (
   $verbose=true,
 ) {
 
+  file { '/usr/src':
+    ensure => directory,
+  }
+
   archive::download {"${name}.${extension}":
     ensure           => $ensure,
     url              => $url,
@@ -55,6 +59,7 @@ define archive (
     allow_insecure   => $allow_insecure,
     follow_redirects => $follow_redirects,
     verbose          => $verbose,
+    require          => File['/usr/src'],
   }
 
   archive::extract {$name:


### PR DESCRIPTION
On some ubuntu systems curl -o doesnt work, changed to curl $src > $tgt
Ensure /mnt/src exists before downloading