### PR TITLE
add  parameter to optionally set --proxy in curl

### DIFF
--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -13,6 +13,7 @@
 # - *$allow_insecure: Default value false.
 # - *$follow_redirects: Default value false.
 # - *$verbose: Default value true.
+# - *$proxy_server: Default value undef.
 #
 # Example usage:
 #
@@ -40,6 +41,7 @@ define archive::download (
   $follow_redirects=false,
   $verbose=true,
   $path=$::path,
+  $proxy_server=undef,
 ) {
 
   $insecure_arg = $allow_insecure ? {
@@ -56,6 +58,12 @@ define archive::download (
     package{'curl':
       ensure => present,
     }
+  }
+
+  if $proxy_server {
+    $proxy_option = "--proxy ${proxy_server}"
+  } else {
+    $proxy_option = ''
   }
 
   case $checksum {
@@ -101,8 +109,9 @@ define archive::download (
               $digest_src = $digest_url
             }
 
+
             exec {"download digest of archive ${name}":
-              command => "curl -s -S ${insecure_arg} ${redirect_arg} -o ${src_target}/${name}.${digest_type} '${digest_src}'",
+              command => "curl ${proxy_option} -s -S ${insecure_arg} ${redirect_arg} -o ${src_target}/${name}.${digest_type} '${digest_src}'",
               creates => "${src_target}/${name}.${digest_type}",
               timeout => $timeout,
               path    => $path,
@@ -144,7 +153,7 @@ define archive::download (
         default => undef,
       }
       exec {"download archive ${name} and check sum":
-        command     => "curl -s -S ${insecure_arg} ${redirect_arg} -o ${src_target}/${name} '${url}'",
+        command     => "curl ${proxy_option} -s -S ${insecure_arg} ${redirect_arg} -o ${src_target}/${name} '${url}'",
         creates     => "${src_target}/${name}",
         logoutput   => true,
         timeout     => $timeout,

--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -63,7 +63,7 @@ define archive::download (
   if $proxy_server {
     $proxy_option = "--proxy ${proxy_server}"
   } else {
-    $proxy_option = ''
+    $proxy_option = undef
   }
 
   case $checksum {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,7 @@
 # - *$follow_redirects: Default value false
 # - *$verbose: Default value true
 # - *$strip_components: Default value 0
+# - *$proxy_server: Default value undef
 #
 # Example usage:
 #
@@ -43,6 +44,7 @@ define archive (
   $follow_redirects=false,
   $verbose=true,
   $strip_components=0,
+  $proxy_server=undef,
 ) {
 
   archive::download {"${name}.${extension}":
@@ -57,6 +59,7 @@ define archive (
     allow_insecure   => $allow_insecure,
     follow_redirects => $follow_redirects,
     verbose          => $verbose,
+    proxy_server     => $proxy_server,
   }
 
   archive::extract {$name:


### PR DESCRIPTION
Some servers may be behind a web proxy, so the `--proxy` option in curl may need to be set.