### PR TITLE
Fix digest_string undef check

### DIFF
--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -103,7 +103,7 @@ define archive::download (
         case $ensure {
           'present': {
 
-            if $digest_url == '' {
+            if !$digest_url {
               $digest_src = "${url}.${digest_type}"
             } else {
               $digest_src = $digest_url


### PR DESCRIPTION
Empty string assignments were changed to undef values. The check for digest_string seems to have been missed and results in curl trying to download from an empty URL if digest_url is unset.

Error: curl  -s -S   -o /usr/src/archive.tar.gz.md5 '' returned 3 instead of one of [0]