### PR TITLE
supprt the purging of target directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ For `.tar.gz` and `tar.bz2` archives, the extract step's `--strip-components=n` 
 strip_components => 1
 ```
 
+```
+purge_target => false
+```
+
+By default the target directory is left intact, this option can be used to `rm -rf` the target directory prior to extraction.
+
 This full example will download the [packer](packer.io) tool to ```/usr/local/bin```:
 
 ```

--- a/manifests/extract.pp
+++ b/manifests/extract.pp
@@ -38,6 +38,7 @@ define archive::extract (
   $timeout=120,
   $path=$::path,
   $strip_components=0,
+  $purge=false,
 ) {
 
   if $root_dir {
@@ -53,12 +54,17 @@ define archive::extract (
       $extract_targz  = "tar --no-same-owner --no-same-permissions --strip-components=${strip_components} -xzf ${src_target}/${name}.${extension} -C ${target}"
       $extract_tarbz2 = "tar --no-same-owner --no-same-permissions --strip-components=${strip_components} -xjf ${src_target}/${name}.${extension} -C ${target}"
 
+      $purge_command = $purge ? {
+        true    => "rm -rf ${target} && ",
+        default => '',
+      }
+
       $command = $extension ? {
-        'zip'     => "mkdir -p ${target} && ${extract_zip}",
-        'tar.gz'  => "mkdir -p ${target} && ${extract_targz}",
-        'tgz'     => "mkdir -p ${target} && ${extract_targz}",
-        'tar.bz2' => "mkdir -p ${target} && ${extract_tarbz2}",
-        'tgz2'    => "mkdir -p ${target} && ${extract_tarbz2}",
+        'zip'     => "${purge_command} mkdir -p ${target} && ${extract_zip}",
+        'tar.gz'  => "${purge_command} mkdir -p ${target} && ${extract_targz}",
+        'tgz'     => "${purge_command} mkdir -p ${target} && ${extract_targz}",
+        'tar.bz2' => "${purge_command} mkdir -p ${target} && ${extract_tarbz2}",
+        'tgz2'    => "${purge_command} mkdir -p ${target} && ${extract_tarbz2}",
         default   => fail ( "Unknown extension value '${extension}'" ),
       }
       exec {"${name} unpack":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@
 #
 # - *$url:
 # - *$target: Destination directory
+# - *$purge_target: Purge Destination prior to extraction. Default false
 # - *$checksum: Default value "true"
 # - *$digest_url: Default value undef
 # - *$digest_string: Default value undef
@@ -45,6 +46,7 @@ define archive (
   $verbose=true,
   $strip_components=0,
   $proxy_server=undef,
+  $purge_target=false,
 ) {
 
   archive::download {"${name}.${extension}":
@@ -65,6 +67,7 @@ define archive (
   archive::extract {$name:
     ensure           => $ensure,
     target           => $target,
+    purge            => $purge_target,
     src_target       => $src_target,
     root_dir         => $root_dir,
     extension        => $extension,

--- a/spec/defines/archive_spec.rb
+++ b/spec/defines/archive_spec.rb
@@ -43,6 +43,18 @@ describe 'archive' do
 
         it { is_expected.to compile.with_all_deps }
       end
+
+      context 'with url and purge target' do
+        let(:params) do
+          {
+            :url => 'http://archive.apache.org/dist/tomcat/tomcat-6/v6.0.26/bin/apache-tomcat-6.0.26.tar.gz',
+            :target => '/opt/tc6',
+            :purge_target => true,
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+      end
     end
   end
 end


### PR DESCRIPTION
add an option to purge the target directory prior to extraction
This is useful in cases where a new version of an archive is not quite
the same as the one it replaces.

This option is potentially dangerous, so we disable it by default ;)