### PR TITLE
Add a params.pp file

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,7 @@
 fixtures:
+  repositories:
+    stdlib:
+      repo: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
+      ref: '4.0.0'
   symlinks:
     archive: "#{source_dir}"

--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -93,7 +93,7 @@ define archive::download (
           'present': {
             file {"${src_target}/${name}.${digest_type}":
               ensure  => $ensure,
-              content => "${digest_string} *${name}",
+              content => "${digest_string} ${::archive::params::binary_indicator}${name}",
               owner   => $user,
               notify  => Exec["download archive ${name} and check sum"],
             }

--- a/manifests/download.pp
+++ b/manifests/download.pp
@@ -78,11 +78,10 @@ define archive::download (
 
   case $checksum {
     true : {
-      case $digest_type {
-        'md5','sha1','sha224','sha256','sha384','sha512' : {
-          $checksum_cmd = "${digest_type}sum -c ${name}.${digest_type}"
-        }
-        default: { fail 'Unimplemented digest type' }
+      if $digest_type in keys($::archive::params::digest_types) {
+          $checksum_cmd = "${::archive::params::digest_types[$digest_type]} -c ${name}.${digest_type}"
+      } else {
+        fail 'Unimplemented digest type'
       }
 
       if $digest_url and $digest_string {

--- a/manifests/extract.pp
+++ b/manifests/extract.pp
@@ -57,9 +57,9 @@ define archive::extract (
     'present': {
 
       $extract_zip    = "unzip -o ${src_target}/${name}.${extension} -d ${target}"
-      $extract_targz  = "${tar_command} --no-same-owner --no-same-permissions --strip-components=${strip_components} -xzf ${src_target}/${name}.${extension} -C ${target}"
-      $extract_tarbz2 = "${tar_command} --no-same-owner --no-same-permissions --strip-components=${strip_components} -xjf ${src_target}/${name}.${extension} -C ${target}"
-      $extract_tarxz  = "${tar_command} --no-same-owner --no-same-permissions --strip-components=${strip_components} -xpf ${src_target}/${name}.${extension} -C ${target}"
+      $extract_targz  = "${::archive::params::tarcmd} --no-same-owner --no-same-permissions --strip-components=${strip_components} -xzf ${src_target}/${name}.${extension} -C ${target}"
+      $extract_tarbz2 = "${::archive::params::tarcmd} --no-same-owner --no-same-permissions --strip-components=${strip_components} -xjf ${src_target}/${name}.${extension} -C ${target}"
+      $extract_tarxz  = "${::archive::params::tarcmd} --no-same-owner --no-same-permissions --strip-components=${strip_components} -xpf ${src_target}/${name}.${extension} -C ${target}"
 
       $purge_command = $purge ? {
         true    => "rm -rf ${target} && ",

--- a/manifests/extract.pp
+++ b/manifests/extract.pp
@@ -47,6 +47,8 @@ define archive::extract (
   },
 ) {
 
+  require ::archive::params
+
   if $root_dir {
     $extract_dir = "${target}/${root_dir}"
   } else {

--- a/manifests/extract.pp
+++ b/manifests/extract.pp
@@ -41,10 +41,7 @@ define archive::extract (
   $strip_components=0,
   $purge=false,
   $user=undef,
-  $tar_command=$::osfamily ? {
-    'Solaris' => 'gtar',
-    default   => 'tar',
-  },
+  $tar_command=undef,
 ) {
 
   require ::archive::params
@@ -55,13 +52,19 @@ define archive::extract (
     $extract_dir = "${target}/${name}"
   }
 
+  if $tar_command {
+    $real_tar_command = $tar_command
+  } else {
+    $real_tar_command = $::archive::params::tarcmd
+  }
+
   case $ensure {
     'present': {
 
       $extract_zip    = "unzip -o ${src_target}/${name}.${extension} -d ${target}"
-      $extract_targz  = "${::archive::params::tarcmd} --no-same-owner --no-same-permissions --strip-components=${strip_components} -xzf ${src_target}/${name}.${extension} -C ${target}"
-      $extract_tarbz2 = "${::archive::params::tarcmd} --no-same-owner --no-same-permissions --strip-components=${strip_components} -xjf ${src_target}/${name}.${extension} -C ${target}"
-      $extract_tarxz  = "${::archive::params::tarcmd} --no-same-owner --no-same-permissions --strip-components=${strip_components} -xpf ${src_target}/${name}.${extension} -C ${target}"
+      $extract_targz  = "${real_tar_command} --no-same-owner --no-same-permissions --strip-components=${strip_components} -xzf ${src_target}/${name}.${extension} -C ${target}"
+      $extract_tarbz2 = "${real_tar_command} --no-same-owner --no-same-permissions --strip-components=${strip_components} -xjf ${src_target}/${name}.${extension} -C ${target}"
+      $extract_tarxz  = "${real_tar_command} --no-same-owner --no-same-permissions --strip-components=${strip_components} -xpf ${src_target}/${name}.${extension} -C ${target}"
 
       $purge_command = $purge ? {
         true    => "rm -rf ${target} && ",

--- a/manifests/extract.pp
+++ b/manifests/extract.pp
@@ -41,10 +41,10 @@ define archive::extract (
   $strip_components=0,
   $purge=false,
   $user=undef,
-  $tar_command=undef,
+  $tar_command=$::archive::params::tarcmd,
 ) {
 
-  require ::archive::params
+  include ::archive::params
 
   if $root_dir {
     $extract_dir = "${target}/${root_dir}"
@@ -52,19 +52,17 @@ define archive::extract (
     $extract_dir = "${target}/${name}"
   }
 
-  if $tar_command {
-    $real_tar_command = $tar_command
-  } else {
-    $real_tar_command = $::archive::params::tarcmd
+  if ! $tar_command {
+    fail("${module_name}: parameter \$tar_command not specified and \$::archive::params::tarcmd not found")
   }
 
   case $ensure {
     'present': {
 
       $extract_zip    = "unzip -o ${src_target}/${name}.${extension} -d ${target}"
-      $extract_targz  = "${real_tar_command} --no-same-owner --no-same-permissions --strip-components=${strip_components} -xzf ${src_target}/${name}.${extension} -C ${target}"
-      $extract_tarbz2 = "${real_tar_command} --no-same-owner --no-same-permissions --strip-components=${strip_components} -xjf ${src_target}/${name}.${extension} -C ${target}"
-      $extract_tarxz  = "${real_tar_command} --no-same-owner --no-same-permissions --strip-components=${strip_components} -xpf ${src_target}/${name}.${extension} -C ${target}"
+      $extract_targz  = "${tar_command} --no-same-owner --no-same-permissions --strip-components=${strip_components} -xzf ${src_target}/${name}.${extension} -C ${target}"
+      $extract_tarbz2 = "${tar_command} --no-same-owner --no-same-permissions --strip-components=${strip_components} -xjf ${src_target}/${name}.${extension} -C ${target}"
+      $extract_tarxz  = "${tar_command} --no-same-owner --no-same-permissions --strip-components=${strip_components} -xpf ${src_target}/${name}.${extension} -C ${target}"
 
       $purge_command = $purge ? {
         true    => "rm -rf ${target} && ",

--- a/manifests/extract.pp
+++ b/manifests/extract.pp
@@ -44,7 +44,7 @@ define archive::extract (
   $tar_command=$::archive::params::tarcmd,
 ) {
 
-  include ::archive::params
+  require ::archive::params
 
   if $root_dir {
     $extract_dir = "${target}/${root_dir}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,6 +53,10 @@ define archive (
   $path = $::path,
 ) {
 
+  include ::archive::params
+  Class['archive::params'] ->
+  Archive[$name]
+
   archive::download {"${name}.${extension}":
     ensure           => $ensure,
     url              => $url,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,8 +54,6 @@ define archive (
 ) {
 
   include ::archive::params
-  Class['archive::params'] ->
-  Archive[$name]
 
   archive::download {"${name}.${extension}":
     ensure           => $ensure,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class archive::params {
         'sha256' => 'sha256',
         'sha512' => 'sha512',
       }
+      $binary_indicator = undef
     }
     default: {
       $tarcmd = 'tar'
@@ -23,6 +24,7 @@ class archive::params {
         'sha384' => 'sha384sum',
         'sha512' => 'sha512sum',
       }
+      $binary_indicator = '*'
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,28 @@
+# Private class, do not use directly
+# steers some defaults of the defined archive types
+
+class archive::params {
+
+  case $::osfamily {
+    'OpenBSD': {
+      $tarcmd = 'gtar'
+      $digest_types = {
+        'md5' => 'md5',
+        'sha1' => 'sha1',
+        'sha256' => 'sha256',
+        'sha512' => 'sha512',
+      }
+    }
+    default: {
+      $tarcmd = 'tar'
+      $digest_types = {
+        'md5' => 'md5sum',
+        'sha1' => 'sha1sum',
+        'sha224' => 'sha224sum',
+        'sha256' => 'sha256sum',
+        'sha384' => 'sha384sum',
+        'sha512' => 'sha512sum',
+      }
+    }
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,18 @@ class archive::params {
       }
       $binary_indicator = undef
     }
+    'Solaris': {
+      $tarcmd = 'gtar'
+      $digest_types = {
+        'md5' => 'md5sum',
+        'sha1' => 'sha1sum',
+        'sha224' => 'sha224sum',
+        'sha256' => 'sha256sum',
+        'sha384' => 'sha384sum',
+        'sha512' => 'sha512sum',
+      }
+      $binary_indicator = '*'
+    }
     default: {
       $tarcmd = 'tar'
       $digest_types = {

--- a/manifests/tar_gz.pp
+++ b/manifests/tar_gz.pp
@@ -1,7 +1,12 @@
 # See README.md for details.
 define archive::tar_gz($source, $target, $path=$::path) {
+
+  include ::archive::params
+  Class['archive::params'] ->
+  Archive::Tar_gz[$name]
+
   exec {"${name} unpack":
-    command => "curl -s -S ${source} | tar -xzf - -C ${target} && touch ${name}",
+    command => "curl -s -S ${source} | ${::archive::params::tarcmd} -xzf - -C ${target} && touch ${name}",
     creates => $name,
     path    => $path,
     require => Package[curl],

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,10 @@
     {
       "operatingsystem": "OpenBSD",
       "operatingsystemrelease": [
-        "5.7"
+        "5.7",
+        "5.8",
+        "5.9",
+        "6.0"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,10 @@
   "issues_url": "https://github.com/camptocamp/puppet-archive/issues",
   "description": "Archive Module for Puppet",
   "dependencies": [
-
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">=4.0.0"
+    }
   ],
   "operatingsystem_support": [
     {
@@ -18,6 +21,12 @@
         "6",
         "7",
         "8"
+      ]
+    },
+    {
+      "operatingsystem": "OpenBSD",
+      "operatingsystemrelease": [
+        "5.7"
       ]
     },
     {


### PR DESCRIPTION
in order to allow OS specific differences to be set
here. It's included in init.pp archive defined type, and make
sure with an order, that it is instantiated in the catalog
before the defined type is executed.

The order of evaluation in the catalog is ensured by the
include line in init.pp, and the following two lines,
setting the order.

The defined variables specific for OpenBSD are:
$tarcmd string, defining a shell command to run tar
$digest_types hash, defining the supported hash types, and their
                    shell commands

The $tarcmd is used in extract.pp, the $digest_types is used
in download.pp

The only extra ::osfamily is OpenBSD, the rest is the values
taken in the default: case of the case statement.

The change in download.pp, uses the keys() function from stdlib.
Because of that, stdlib is added as dependency to metadata.json,
and .fixtures.yml. I chose an arbitrary version as minimal version
not too old, and not too recent. Otherwise, stdlib 3.X should
also work.

Added OpenBSD to the metadata.json, in order to get the specs
covering it too.

Let me know if there is something wrong, or needs change/enhancement etc.
