### PR TITLE
Ported to Windows

### DIFF
--- a/manifests/extract.pp
+++ b/manifests/extract.pp
@@ -43,6 +43,13 @@ define archive::extract (
   $user=undef,
 ) {
 
+   # JOE
+	if $::osfamily == 'Windows' {
+	  $exec_provider = 'cygwin'
+	} else { 
+	  $exec_provider = 'posix'
+	} 
+  
   if $root_dir {
     $extract_dir = "${target}/${root_dir}"
   } else {
@@ -52,7 +59,7 @@ define archive::extract (
   case $ensure {
     'present': {
 
-      $extract_zip    = "unzip -o ${src_target}/${name}.${extension} -d ${target}"
+      $extract_zip    = "unzip -o '${src_target}/${name}.${extension}' -d '${target}'"
       $extract_targz  = "tar --no-same-owner --no-same-permissions --strip-components=${strip_components} -xzf ${src_target}/${name}.${extension} -C ${target}"
       $extract_tarbz2 = "tar --no-same-owner --no-same-permissions --strip-components=${strip_components} -xjf ${src_target}/${name}.${extension} -C ${target}"
       $extract_tarxz  = "tar --no-same-owner --no-same-permissions --strip-components=${strip_components} -xpf ${src_target}/${name}.${extension} -C ${target}"
@@ -78,6 +85,7 @@ define archive::extract (
         timeout => $timeout,
         user    => $user,
         path    => $path,
+		  provider => $exec_provider,
       }
     }
     'absent': {

--- a/metadata.json
+++ b/metadata.json
@@ -11,6 +11,9 @@
   "dependencies": [
 
   ],
+    { "name": "puppetlabs/stdlib", "version_requirement": ">=3.2.0 <5.0.0" },
+	 { "name": "johnericson/cygwin_exec", "version_requirement": ">=0.1.0" }
+  ]
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",


### PR DESCRIPTION
I would like to merge my changes in this module. I have ported the module so it now also works on Windows and used it successfully in a mixed Windows/Linux environment for several months. In order to minimize the changes required in order to make it run on Windows I've relied on Cygwin for providing the Unix commands needed for the many execs. Where packages is needed I've used Chocolatey which is a package management tool for Windows.

I'm relying on the changes in this module for making the Puppet-Pentaho (https://github.com/JohnEricson/puppet-pentaho) module working on both Linux and Windows.